### PR TITLE
iOS 10 stickers support!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Imoji SDK Changes
 
+### Version 2.3.0
+
+* Adds support for rendering Imoji stickers as MSStickers for iOS 10! See [https://developer.apple.com/reference/messages/mssticker](https://developer.apple.com/reference/messages/mssticker)
+* Addresses an issue with exporting non gif images as PNG
+* Make sure renderAnimatedIfSupported is set to true for [IMImojiObjectRenderingOptions optionsWithAnimationAndRenderSize]
+
 ### Version 2.2.1
 
 * Adds **relatedCategories** to search results. Clients can use this to show multiple related terms instead of just one (relatedSearchTerm).

--- a/ImojiSDK.podspec
+++ b/ImojiSDK.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
 
   s.name     = 'ImojiSDK'
-  s.version  = '2.2.1'
+  s.version  = '2.3.0'
   s.license  = 'MIT'
   s.summary  = 'iOS SDK for Imoji. Integrate Stickers and custom emojis into your applications easily!'
-  s.homepage = 'http://imoji.io/sdk'
+  s.homepage = 'http://imoji.io/developers'
   s.authors = {'Nima Khoshini'=>'nima@imojiapp.com', 'Alex Hoang'=>'alex@imojiapp.com'}
   s.libraries = 'z'
 

--- a/Source/Core/IMImojiObjectRenderingOptions.m
+++ b/Source/Core/IMImojiObjectRenderingOptions.m
@@ -132,7 +132,9 @@
 }
 
 + (instancetype)optionsWithAnimationAndRenderSize:(IMImojiObjectRenderSize)renderSize {
-    return [[IMImojiObjectRenderingOptions alloc] initWithRenderSize:renderSize borderStyle:IMImojiObjectBorderStyleNone imageFormat:IMImojiObjectImageFormatAnimatedGif];
+    IMImojiObjectRenderingOptions* options = [[IMImojiObjectRenderingOptions alloc] initWithRenderSize:renderSize borderStyle:IMImojiObjectBorderStyleNone imageFormat:IMImojiObjectImageFormatAnimatedGif];
+    options.renderAnimatedIfSupported = YES;
+    return options;
 }
 
 @end

--- a/Source/Core/IMImojiSession.h
+++ b/Source/Core/IMImojiSession.h
@@ -201,6 +201,15 @@ typedef void (^IMImojiSessionCreationResponseCallback)(IMImojiObject *__nullable
 typedef void (^IMImojiSessionExportedImageResponseCallback)(UIImage *__nullable image, NSData *__nullable data, NSString *__nullable typeIdentifier, NSError *__nullable error);
 
 /**
+* @abstract Callback used for exporting Imoji to an NSData reference for export (ex: sharing to iMessage, Instagram, etc).
+* @param image UIImage representation of the IMImojiObject.
+* @param data NSData reference safe for exporting.
+* @param typeIdentifier Either kUTTypeGIF or kUTTypePNG if the operation succeeded. nil otherwise.
+* @param error An error with code equal to an IMImojiSessionErrorCode value or nil if the request succeeded.
+*/
+typedef void (^IMImojiSessionMSStickerResponseCallback)(NSObject *__nullable msStickerObject, NSError *__nullable error);
+
+/**
 * @abstract Callback used for fetching attribution for IMImoji identifiers.
 * @param attribution Dictionary object with the requested IMImoji id's as keys and IMCategoryAttribution objects as values
 * @param error An error with code equal to an IMImojiSessionErrorCode value or nil if the request succeeded
@@ -351,6 +360,18 @@ typedef void (^IMImojiSessionImojiAttributionResponseCallback)(NSDictionary *__n
 - (nonnull NSOperation *)renderImojiForExport:(nonnull IMImojiObject *)imoji
                                       options:(nonnull IMImojiObjectRenderingOptions *)options
                                      callback:(nonnull IMImojiSessionExportedImageResponseCallback)callback;
+
+/**
+ * @abstract Renders an imoji object as an MSSticker object
+ * @param imoji The imoji to render.
+ * @param options Set of options to render the imoji with.
+ * @param callback Called once the imoji image and data have been rendered.
+ * @see [MSSticker](https://developer.apple.com/reference/messages/mssticker)
+ * @return An operation reference that can be used to cancel the request.
+ */
+- (nonnull NSOperation *)renderImojiAsMSSticker:(nonnull IMImojiObject *)imoji
+                                        options:(nonnull IMImojiObjectRenderingOptions *)options
+                                       callback:(nonnull IMImojiSessionMSStickerResponseCallback)callback;
 @end
 
 @interface IMImojiSession (CollectionManagement)

--- a/Source/Core/IMImojiSession.m
+++ b/Source/Core/IMImojiSession.m
@@ -841,7 +841,7 @@ NSString *const IMImojiSessionErrorDomain = @"IMImojiSessionErrorDomain";
                                      if (error) {
                                          callback(nil, error);
                                      } else {
-                                         [UIImagePNGRepresentation(image) writeToURL:url atomically:YES];
+                                         [data writeToURL:url atomically:YES];
                                          stickerCallback();
                                      }
                                      

--- a/Source/Core/IMImojiSession.m
+++ b/Source/Core/IMImojiSession.m
@@ -801,7 +801,7 @@ NSString *const IMImojiSessionErrorDomain = @"IMImojiSessionErrorDomain";
                                  reason:@"MSSticker rendering only supported with iOS 10 SDK and higher"
                                userInfo:nil] raise];
 
-        return [NSOperation new];
+        return self.cancellationTokenOperation;
     }
 
     __block NSURL *url = [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@%@-%@.%@",
@@ -830,7 +830,7 @@ NSString *const IMImojiSessionErrorDomain = @"IMImojiSessionErrorDomain";
             return nil;
         }];
         
-        return [NSOperation new];
+        return self.cancellationTokenOperation;
     }
 
 
@@ -852,6 +852,8 @@ NSString *const IMImojiSessionErrorDomain = @"IMImojiSessionErrorDomain";
     [[NSException exceptionWithName:@"imoji runtime exception"
                             reason:@"MSSticker rendering only supported with iOS 10 SDK and higher"
                           userInfo:nil] raise];
+    
+    return self.cancellationTokenOperation;
 #endif
 }
 

--- a/Source/Core/IMImojiSession.m
+++ b/Source/Core/IMImojiSession.m
@@ -37,6 +37,11 @@
 #import "IMMutableCategoryAttribution.h"
 #import "IMCategoryFetchOptions.h"
 
+#if IMMessagesFrameworkSupported
+#import <Messages/Messages.h>
+#import "BFTask+Utils.h"
+#endif
+
 NSString *const IMImojiSessionErrorDomain = @"IMImojiSessionErrorDomain";
 
 @implementation IMImojiSession
@@ -719,7 +724,7 @@ NSString *const IMImojiSessionErrorDomain = @"IMImojiSessionErrorDomain";
             NSError *exportError = nil;
             NSString *typeIdentifier = nil;
 
-            if (imoji.supportsAnimation) {
+            if (imoji.supportsAnimation && options.renderAnimatedIfSupported) {
                 if ([image isKindOfClass:[YYImage class]]) {
                     YYImage *yyImage = (YYImage *) image;
 
@@ -785,6 +790,69 @@ NSString *const IMImojiSessionErrorDomain = @"IMImojiSessionErrorDomain";
             callback(image, attachmentData, typeIdentifier, exportError);
         }
     }];
+}
+
+- (nonnull NSOperation *)renderImojiAsMSSticker:(nonnull IMImojiObject *)imoji
+                                        options:(nonnull IMImojiObjectRenderingOptions *)options
+                                       callback:(nonnull IMImojiSessionMSStickerResponseCallback)callback {
+#if IMMessagesFrameworkSupported
+    if (!NSClassFromString(@"MSSticker")) {
+        [[NSException exceptionWithName:@"imoji runtime exception"
+                                 reason:@"MSSticker rendering only supported with iOS 10 SDK and higher"
+                               userInfo:nil] raise];
+
+        return [NSOperation new];
+    }
+
+    __block NSURL *url = [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@%@-%@.%@",
+                                                                   NSTemporaryDirectory(),
+                                                                   imoji.identifier,
+                                                                   @(options.hash),
+                                                                   imoji.supportsAnimation ? @"gif" : @"png"
+    ]];
+    __block void (^stickerCallback)() = ^{
+        NSError *stickerError;
+        MSSticker *sticker = [[MSSticker alloc] initWithContentsOfFileURL:url
+                                                     localizedDescription:imoji.identifier
+                                                                    error:&stickerError];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (stickerError) {
+                callback(nil, stickerError);
+            } else {
+                callback(sticker, nil);
+            }
+        });
+    };
+
+    if ([[NSFileManager defaultManager] fileExistsAtPath:url.path]) {
+        [BFTask im_concurrentBackgroundTaskWithBlock:^id(BFTask *task) {
+            stickerCallback();
+            return nil;
+        }];
+        
+        return [NSOperation new];
+    }
+
+
+    return [self renderImojiForExport:imoji
+                              options:options
+                             callback:^(UIImage *image, NSData *data, NSString *typeIdentifier, NSError *error) {
+                                 [BFTask im_concurrentBackgroundTaskWithBlock:^id(BFTask *task) {
+                                     if (error) {
+                                         callback(nil, error);
+                                     } else {
+                                         [UIImagePNGRepresentation(image) writeToURL:url atomically:YES];
+                                         stickerCallback();
+                                     }
+                                     
+                                     return nil;
+                                 }];
+                             }];
+#else
+    [[NSException exceptionWithName:@"imoji runtime exception"
+                            reason:@"MSSticker rendering only supported with iOS 10 SDK and higher"
+                          userInfo:nil] raise];
+#endif
 }
 
 - (void)renderImoji:(IMMutableImojiObject *)imoji

--- a/Source/Core/ImojiSDK.h
+++ b/Source/Core/ImojiSDK.h
@@ -31,6 +31,12 @@
 #import "IMImojiSessionStoragePolicy.h"
 #import "IMImojiSession.h"
 
+#if __has_include(<Messages/Messages.h>)
+#define IMMessagesFrameworkSupported 1
+#else
+#define IMMessagesFrameworkSupported 0
+#endif
+
 /**
 * @abstract Base class for coordinating with other ImojiSDK classes
 */


### PR DESCRIPTION
* Adds support for rendering Imoji stickers as MSStickers for iOS 10! See [https://developer.apple.com/reference/messages/mssticker](https://developer.apple.com/reference/messages/mssticker)
* Addresses an issue with exporting non gif images as PNG
* Make sure renderAnimatedIfSupported is set to true for [IMImojiObjectRenderingOptions optionsWithAnimationAndRenderSize]