### PR TITLE
Adds new object type IMImojiImageReference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Imoji SDK Changes
 
+### Version 2.3.2
+
+* Adds new object type IMImojiImageReference
+* Adds new argument contributingImojiId to method searchImojisWithTerm. When contributingImojiId is not nil, the server returns a set of imojis with the contributing imoji as the first result.
+* Deprecated searchImojisWithTerm without the contributingImojiId argument. It is still supported.
+
 ### Version 2.3.1
 
 * Expose initWithCachePath:persistentPath: in IMImojiSessionStoragePolicy for overriding

--- a/ImojiSDK.podspec
+++ b/ImojiSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name     = 'ImojiSDK'
-  s.version  = '2.3.1'
+  s.version  = '2.3.2'
   s.license  = 'MIT'
   s.summary  = 'iOS SDK for Imoji. Integrate Stickers and custom emojis into your applications easily!'
   s.homepage = 'http://imoji.io/developers'

--- a/Source/Core/IMImojiImageReference.h
+++ b/Source/Core/IMImojiImageReference.h
@@ -25,10 +25,20 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+* An IMImojiImageReference represents a sticker image and its identifier
+*/
 @interface IMImojiImageReference : NSObject
 
-@property(nonatomic, strong) UIImage *image;
-@property(nonatomic, strong) NSString *identifier;
+/**
+* @abstract The image associated with the imoji identifier. This field is never nil.
+*/
+@property(nonatomic, strong, nonnull) UIImage *image;
+
+/**
+* @abstract A unique identifier for the imoji. This field is never nil.
+*/
+@property(nonatomic, strong, nonnull) NSString *identifier;
 
 + (instancetype)referenceWithIdentifier:(NSString *)identifier image:(UIImage *)image;
 

--- a/Source/Core/IMImojiImageReference.h
+++ b/Source/Core/IMImojiImageReference.h
@@ -1,0 +1,35 @@
+//
+//  ImojiSDK
+//
+//  Created by Alex Hoang
+//  Copyright (C) 2016 Imoji
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface IMImojiImageReference : NSObject
+
+@property(nonatomic, strong) UIImage *image;
+@property(nonatomic, strong) NSString *identifier;
+
++ (instancetype)referenceWithIdentifier:(NSString *)identifier image:(UIImage *)image;
+
+@end

--- a/Source/Core/IMImojiImageReference.m
+++ b/Source/Core/IMImojiImageReference.m
@@ -1,0 +1,45 @@
+//
+//  ImojiSDK
+//
+//  Created by Alex Hoang
+//  Copyright (C) 2016 Imoji
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+//
+
+#import "IMImojiImageReference.h"
+#import "IMCategoryAttribution.h"
+
+@implementation IMImojiImageReference
+
+- (instancetype)initWithIdentifier:(NSString *)identifier image:(UIImage *)image {
+    self = [super init];
+    if (self) {
+        _identifier = identifier;
+        _image = image;
+    }
+
+    return self;
+}
+
++ (instancetype)referenceWithIdentifier:(NSString *)identifier image:(UIImage *)image {
+    return [[IMImojiImageReference alloc] initWithIdentifier:identifier image:image];
+}
+
+@end

--- a/Source/Core/IMImojiSession.h
+++ b/Source/Core/IMImojiSession.h
@@ -290,9 +290,28 @@ typedef void (^IMImojiSessionImojiAttributionResponseCallback)(NSDictionary *__n
 * @param resultSetResponseCallback Callback triggered when the search results are available or if an error occurred.
 * @param imojiResponseCallback Callback triggered when an imoji is available to render.
 * @return An operation reference that can be used to cancel the request.
+* DEPRECATED: Use searchImojisWithTerm:offset:contributingImojiId:numberOfResults:resultSetResponseCallback:imojiResponseCallback: instead
 */
 - (nonnull NSOperation *)searchImojisWithTerm:(nullable NSString *)searchTerm
                                        offset:(nullable NSNumber *)offset
+                              numberOfResults:(nullable NSNumber *)numberOfResults
+                    resultSetResponseCallback:(nonnull IMImojiSessionResultSetResponseCallback)resultSetResponseCallback
+                        imojiResponseCallback:(nonnull IMImojiSessionImojiFetchedResponseCallback)imojiResponseCallback DEPRECATED_ATTRIBUTE;
+
+/**
+* @abstract Searches the imojis database with a given search term. The resultSetResponseCallback block is called once the results are available.
+* Imoji contents are downloaded individually and imojiResponseCallback is called once the thumbnail of that imoji has been downloaded.
+* @param searchTerm Search term to find imojis with. If nil or empty, the server will typically returned the featured set of imojis (this is subject to change).
+* @param offset The result offset from a previous search. This may be nil.
+* @param numberOfResults Number of results to fetch. This can be nil.
+* @param contributingImojiId The imoji identifier associated with a category's image. This can be nil. If not nil, the server returns a set of imojis with the contributing imoji as the first result.
+* @param resultSetResponseCallback Callback triggered when the search results are available or if an error occurred.
+* @param imojiResponseCallback Callback triggered when an imoji is available to render.
+* @return An operation reference that can be used to cancel the request.
+*/
+- (nonnull NSOperation *)searchImojisWithTerm:(nullable NSString *)searchTerm
+                                       offset:(nullable NSNumber *)offset
+                          contributingImojiId:(nullable NSString *)contributingImojiId
                               numberOfResults:(nullable NSNumber *)numberOfResults
                     resultSetResponseCallback:(nonnull IMImojiSessionResultSetResponseCallback)resultSetResponseCallback
                         imojiResponseCallback:(nonnull IMImojiSessionImojiFetchedResponseCallback)imojiResponseCallback;

--- a/Source/Core/IMImojiSession.m
+++ b/Source/Core/IMImojiSession.m
@@ -170,6 +170,15 @@ NSString *const IMImojiSessionErrorDomain = @"IMImojiSessionErrorDomain";
                       numberOfResults:(NSNumber *)numberOfResults
             resultSetResponseCallback:(IMImojiSessionResultSetResponseCallback)resultSetResponseCallback
                 imojiResponseCallback:(IMImojiSessionImojiFetchedResponseCallback)imojiResponseCallback {
+    return [self searchImojisWithTerm:searchTerm offset:offset contributingImojiId:nil numberOfResults:numberOfResults resultSetResponseCallback:resultSetResponseCallback imojiResponseCallback:imojiResponseCallback];
+}
+
+- (NSOperation *)searchImojisWithTerm:(NSString *)searchTerm
+                               offset:(NSNumber *)offset
+                  contributingImojiId:(NSString *)contributingImojiId
+                      numberOfResults:(NSNumber *)numberOfResults
+            resultSetResponseCallback:(IMImojiSessionResultSetResponseCallback)resultSetResponseCallback
+                imojiResponseCallback:(IMImojiSessionImojiFetchedResponseCallback)imojiResponseCallback {
     __block NSOperation *cancellationToken = self.cancellationTokenOperation;
 
     if (numberOfResults && numberOfResults.integerValue <= 0) {
@@ -185,6 +194,10 @@ NSString *const IMImojiSessionErrorDomain = @"IMImojiSessionErrorDomain";
             @"numResults" : numberOfResults != nil ? numberOfResults : [NSNull null],
             @"offset" : offset != nil ? offset : @0
     }];
+
+    if (contributingImojiId) {
+        parameters[@"contributingImojiId"] = contributingImojiId;
+    }
 
     [[self runValidatedGetTaskWithPath:@"/imoji/search" andParameters:parameters] continueWithExecutor:[BFExecutor mainThreadExecutor] withBlock:^id(BFTask *getTask) {
         NSDictionary *results = getTask.result;


### PR DESCRIPTION
Adds new argument contributingImojiId to method searchImojisWithTerm. When contributingImojiId is not nil, the server returns a set of imojis with the contributing imoji as the first result.
Deprecated searchImojisWithTerm without the contributingImojiId argument. It is still supported.